### PR TITLE
Fix crash on call to SarAsioWrapper::stop before SarAsioWrapper::start

### DIFF
--- a/SarAsio/wrapper.cpp
+++ b/SarAsio/wrapper.cpp
@@ -94,7 +94,9 @@ AsioStatus SarAsioWrapper::stop()
         return AsioStatus::OK;
     }
 
-    _sar->stop();
+    if(_sar)
+        _sar->stop();
+
     return _innerDriver->stop();
 }
 


### PR DESCRIPTION
FL Studio seems to call stop before ever calling star, which would cause a null pointer dereference here. 
Doesn't hurt to add an extra check here