### PR TITLE
Fix ASIO HW combobox dropdown size

### DIFF
--- a/SarAsio/SarAsio.rc
+++ b/SarAsio/SarAsio.rc
@@ -44,7 +44,7 @@ FONT 8, "MS Shell Dlg", 400, 0, 0
         8, 8, 304, 28,
         0, WS_EX_LEFT
     COMBOBOX 1001,
-        14, 18, 244, 17,
+        14, 18, 244, 128,
         CBS_DROPDOWNLIST | CBS_HASSTRINGS, WS_EX_LEFT
     PUSHBUTTON "&Configure", 1002,
         262, 17, 44, 14,


### PR DESCRIPTION
In MFC, the combobox height define the height of the combobox + its
dropdown list, as said here [0]:

> The height parameter applies to the height of a combo box with a
> drop-down list fully expanded.

The height wasn't enough to old one item and could cause the dropdown list
to be empty despite still having items.

So increase it so at least some items are shown.

[0] https://docs.microsoft.com/en-us/windows/desktop/menurc/combobox-control

Fix: eiz#56